### PR TITLE
Release 1.0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A micro-library for Clojure that provides first class support for accessing the values of [named-capturing groups](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html#groupname) in regular expressions. It has no dependencies, other than on Clojure and any supported JVM, and is [less than 100 lines of code](https://github.com/pmonks/rencg/blob/main/src/rencg/api.clj).
 
-## Why not [rufoa/named-re](https://github.com/rufoa/named-re)?
+#### Why not [rufoa/named-re](https://github.com/rufoa/named-re)?
 
 Because that library [monkey patches core Clojure](https://github.com/rufoa/named-re/blob/master/src/named_re/core.clj#L26-L32), which may break other code.
 
@@ -39,9 +39,9 @@ $ lein try com.github.pmonks/rencg
 $ deps-try com.github.pmonks/rencg
 ```
 
-### API Documentation
+## Usage
 
-[API documentation is available here](https://pmonks.github.io/rencg/), or [here on cljdoc](https://cljdoc.org/d/com.github.pmonks/rencg/).
+[API documentation is available here](https://pmonks.github.io/rencg/), or [here on cljdoc](https://cljdoc.org/d/com.github.pmonks/rencg/), and the [unit tests](https://github.com/pmonks/rencg/blob/main/test/rencg/api_test.clj) are also worth perusing to see worked examples.
 
 ## Contributor Information
 

--- a/pbr.clj
+++ b/pbr.clj
@@ -21,7 +21,7 @@
   [opts]
   (assoc opts
          :lib          'com.github.pmonks/rencg
-         :version      (pbr/calculate-version 0 1)
+         :version      (pbr/calculate-version 1 0)
          :write-pom    true
          :validate-pom true
          :pom          {:description      "A micro-library for Clojure that provides first class support for named-capturing groups in regular expressions."

--- a/test/rencg/api_test.clj
+++ b/test/rencg/api_test.clj
@@ -40,6 +40,7 @@
 
 (deftest re-matches-ncg-tests
   (testing "Nil regexes and/or input strings"
+    ; Not a fan of throwing exceptions in these cases, but for better or worse this behaviour is compatible with clojure.core/re-matches
     (is (thrown? java.lang.NullPointerException (re-matches-ncg nil   nil)))
     (is (thrown? java.lang.NullPointerException (re-matches-ncg #".*" nil)))
     (is (thrown? java.lang.NullPointerException (re-matches-ncg nil   ""))))

--- a/test/rencg/api_test.clj
+++ b/test/rencg/api_test.clj
@@ -66,7 +66,7 @@
     (is (= {"name" "Apache", "version" "2"}   (re-matches-ncg apache-re         "Apache Software License Version 2"))))
   (testing "3-arg version"
     (let [ncgs (re-named-groups apache-re)]
-      ; Note: these cases nonsensical since the names in ncgs don't correlate to the regexes, but we test these cases anyway to ensure correct behaviour
+      ; Note: these cases are nonsensical since the names in ncgs don't correlate to the regexes, but we test these cases anyway to ensure reasonable behaviour
       (is (nil?                                 (re-matches-ncg #"foo"         ""                                  ncgs)))
       (is (nil?                                 (re-matches-ncg #"(?<foo>foo)" ""                                  ncgs)))
       (is (= {}                                 (re-matches-ncg #"foo"         "foo"                               ncgs)))


### PR DESCRIPTION
com.github.pmonks/rencg release 1.0.26. See commit log for details of what's included in this release.